### PR TITLE
Minor Fixes

### DIFF
--- a/watcher/main.go
+++ b/watcher/main.go
@@ -249,7 +249,7 @@ func analyzeArticle(articleListItem types.ArticlesListItem, browser *rod.Browser
 
 	//get subtitle if there is
 	if website.SubtitleElement != "" {
-		subtitleElement, err := page.ElementX(website.SubtitleElement)
+		subtitleElement, err := page.Timeout(10 * time.Second).ElementX(website.SubtitleElement)
 		if err != nil {
 			log.Println(err.Error())
 			return false, err

--- a/watcher/utils.go
+++ b/watcher/utils.go
@@ -42,6 +42,8 @@ var (
 		"January 2 2006 3:04 PM",
 		"January 02 2006 3:04 PM",
 		"2006-01-02",
+		"January 02 2006",
+		"January 2 2006",
 
 		// Specific format for your CNN/news case
 		"3:04 PM MST Mon October 2 2006",

--- a/websites.json
+++ b/websites.json
@@ -112,7 +112,7 @@
   {
     "name": "ABC News",
     "url": "https://abcnews.go.com/Technology",
-    "mainElement": "//section[contains(@class,'ContentRoll__Item')]",
+    "mainElement": "//section[contains(@class,'ContentRoll__Item') and not(.//div[contains(@class,'Video')])]",
     "titleElement": ".//h2/a",
     "anchorElement": ".//h2/a",
     "imageElement": ".//img",


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and accuracy of the article analyzer and date parsing in the `watcher` project. The most important changes include adding a timeout to subtitle element fetching, updating date formats, and refining the main element selection for ABC News.

Improvements to subtitle element fetching:

* [`watcher/main.go`](diffhunk://#diff-63df52e9290d59962dc451a6bd1951c95c52db52b4a9781de7fded8201bda095L252-R252): Added a 10-second timeout to the `ElementX` method when fetching the subtitle element to prevent indefinite waiting.

Updates to date formats:

* [`watcher/utils.go`](diffhunk://#diff-d389ff8f421deb319ee31e3d615cb60124ed99a5aba38c7824c114cc58ba9f2cR45-R46): Added two new date formats to the list of recognized formats for date parsing.

Refinements to main element selection:

* [`websites.json`](diffhunk://#diff-9c03df59ad6917ea2c8aad46813803a8302c3cf4a9396997c1a34e44b3504cd6L115-R115): Updated the `mainElement` selector for ABC News to exclude sections containing videos, ensuring only relevant content is processed.